### PR TITLE
Secret management example

### DIFF
--- a/nginx/deployment.yaml
+++ b/nginx/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: quay.io/jpacker/nginx:1.16.1
+        image: quay.io/jpacker/nginx:1.14.1
         ports:
         - containerPort: 8080
         imagePullPolicy: Always

--- a/nginx/deployment.yaml
+++ b/nginx/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: quay.io/jpacker/nginx:1.14.1
+        image: quay.io/jpacker/nginx:1.16.1
         ports:
         - containerPort: 8080
         imagePullPolicy: Always

--- a/secret-management/README.md
+++ b/secret-management/README.md
@@ -4,7 +4,7 @@
 How do I define secrets in my ACM hub cluster and securly distribute them to my managed clusters?
 
 ## Solution
-Red Hat ACM Namespace channel has a special secret feature.  This takes a secret from the Namespace you define for the channel and delivers it as a secret to the managed endpoints matching the placement rule.
+Red Hat ACM Namespace channel has a special secret feature.  This takes a secret from the namespace you define for the channel and delivers it as a secret to the managed-clusters matching the placement rule.
 
 ## The pieces
 ### app.yaml

--- a/secret-management/README.md
+++ b/secret-management/README.md
@@ -1,0 +1,44 @@
+# Managed your secrets in Red Hat ACM
+
+## Problem
+How do I define secrets in my ACM hub cluster and securly distribute them to my managed clusters?
+
+## Solution
+Red Hat ACM Namespace channel has a special secret feature.  This takes a secret from the Namespace you define for the channel and delivers it as a secret to the managed endpoints matching the placement rule.
+
+## The pieces
+### app.yaml
+This defines the Application object that groups all the subscriptions you want to use to distribute your secrets together.
+
+### channel.yaml
+This defines a namespace `my-secrets-ch` where you are exptect to create the secrets you want to distrbute.  The channel name will be `my-secret`, so the channel path you define in the subscription is `NAMESPACE/SECRET` or `my-secrets-ch/my-secret`.
+
+### placement.yaml
+This defines the target clusters where you want your secret(s) delivered. You can have one placement rule or many.  Placement rules can be shared between subscriptions.  You can modify the labelSelector or the MatchExpression to define the target clusters.
+
+### namespace.yaml
+This defines the `my-secret-ch` namespace for the channel and `my-secret` namespace where the example subscription will be created.
+
+### subscription.yaml
+This defines a subscription. It has a reference to the `my-secret-ch/my-secret` channel. It also has a `placementRef` that points to the placement rule. By default a subscription will pull all secrets in the channel. So if you want to limit a subscription to specific secrets you create the channel namespace `my-secret-ch` you would add an annotation to the actual YAML secret created in the `my-secret-ch` namespace.
+
+In the subscription to choose a secret by annotation use:
+```yaml
+  packageFilter:
+    annotations:
+      secretname: my-secret
+```
+Any secret with the metadata.annotations.`secretname`: `my-secret` will be delivered to the clusters defined in the placement rule the subscription references. 
+
+### secret.yaml
+Define one or more secrets to apply the channel namespace `my-secret-ch`. You need to include the following annotation always: 
+```yaml
+metadata:
+  annotations:
+    apps.open-cluster-management.io/deployables: "secret"
+    secretname: my-secret    # This is an optional filter, that just needs to match the
+                             # subscrpition packageFilter mentioned above.
+```
+
+### Note
+The key to remember, to have your secrets in the Hub channel delivered, they need the `aps.open-cluster-management.io/deployables` annotation, and optionally additional annotations for filtering secrets for delivery.

--- a/secret-management/README.md
+++ b/secret-management/README.md
@@ -31,14 +31,14 @@ In the subscription to choose a secret by annotation use:
 Any secret with the metadata.annotations.`secretname`: `my-secret` will be delivered to the clusters defined in the placement rule the subscription references. 
 
 ### secret.yaml
-Define one or more secrets to apply the channel namespace `my-secret-ch`. You need to include the following annotation always: 
+Define one or more secrets for the channel namespace `my-secret-ch`. You need to include the following annotation: 
 ```yaml
 metadata:
   annotations:
-    apps.open-cluster-management.io/deployables: "secret"
+    apps.open-cluster-management.io/deployables: "secret"  # REQUIRED
     secretname: my-secret    # This is an optional filter, that just needs to match the
-                             # subscrpition packageFilter mentioned above.
+                             # subscrpition packageFilter mentioned above to select this secret
 ```
 
-### Note
-The key to remember, to have your secrets in the Hub channel delivered, they need the `aps.open-cluster-management.io/deployables` annotation, and optionally additional annotations for filtering secrets for delivery.
+### Note Important
+Your secrets need the `aps.open-cluster-management.io/deployables` annotation to be delivered.  To filter out which secrets to deliver, use a unique key and value pair for the `packageFilter` on the Subscription.

--- a/secret-management/app.yaml
+++ b/secret-management/app.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: my-secret
+  namespace: 
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: 
+          - my-secret

--- a/secret-management/channel.yaml
+++ b/secret-management/channel.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: my-secrets
+  namespace: my-secrets-ch
+spec:
+  type: Namespace
+  pathname: my-secrets
+  sourceNamespaces:
+    - my-secrets-ch

--- a/secret-management/kustomization.yaml
+++ b/secret-management/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- channel.yaml
+- placement.yaml
+- subscription.yaml
+- secrets.yaml

--- a/secret-management/namespace.yaml
+++ b/secret-management/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-secrets-ch
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-secrets

--- a/secret-management/placement.yaml
+++ b/secret-management/placement.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  annotations:
+    secretname: my-secret
+  name: my-secrets-placement
+  namespace: my-secrets
+spec:
+  clusterSelector:
+    matchLabels:
+      'usage': 'development'

--- a/secret-management/secret.yaml
+++ b/secret-management/secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hive43-aws-test-install-config
+  annotations: 
+    apps.open-cluster-management.io/deployables: "secret"
+    secretname: my-secret
+
+type: Opaque
+stringData:
+  # Base64 encoding of install-config yaml
+  key: encodedValue

--- a/secret-management/subscription.yaml
+++ b/secret-management/subscription.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: my-secrets
+  namespace: my-secrets
+  labels:
+    app: my-secret
+spec:
+  channel: my-secrets-ch/my-secrets
+  packageFilter:
+    annotations:
+      secretname: my-secret
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: my-secrets-placement
+
+
+


### PR DESCRIPTION
Signed off by @jnpacker 

* Example of using a `Namespace` channel to securely deliver secrets defined on the ACM hub to managed clusters.